### PR TITLE
cache: add ShardedLRUCache and unit tests

### DIFF
--- a/trpc/util/cache/decorators/BUILD
+++ b/trpc/util/cache/decorators/BUILD
@@ -43,3 +43,24 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_library(
+    name = "sharded_lru_cache",
+    hdrs = ["sharded_lru_cache.h"],
+    deps = [
+        "//trpc/util/cache",
+        "//trpc/util/concurrency:lightly_concurrent_hashmap",
+    ],
+)
+
+cc_test(
+    name = "sharded_lru_cache_test",
+    srcs = ["sharded_lru_cache_test.cc"],
+    deps = [
+        ":sharded_lru_cache",
+        "//trpc/util/cache/impl:basic_cache",
+        "//trpc/util/cache/decorators:lru_cache",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/trpc/util/cache/decorators/sharded_lru_cache.h
+++ b/trpc/util/cache/decorators/sharded_lru_cache.h
@@ -1,0 +1,162 @@
+/*
+ *
+ * Tencent is pleased to support the open source community by making
+ * tRPC available.
+ *
+ * Copyright (C) 2025 Tencent.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <type_traits>
+#include <utility>
+
+#include "../impl/basic_cache.h"
+#include "lru_cache.h"
+namespace trpc::cache {
+
+/// @brief This LRU cache, based on bitwise sharding (2^ShardBits), implements approximate global LRU and strict LRU
+/// within shards. Each shard consists of an `LRUCache` (decorator) + a pluggable base (default `BasicCache`). Shards
+/// are not locked, improving concurrency.
+///
+/// Key Design Points:
+/// 1) Sharding: Number of shards = 2^ShardBits. Shards are selected using Hash & (N-1);
+/// 2) Capacity: Total capacity is evenly divided among shards, with the remainder allocated to the first few shards;
+///    each shard has a capacity of at least 1;
+/// 3) Thread-Safety: LRUCache's Mutex ensures intra-shard locks; no global
+///    locks are required between shards;
+/// 4) Pluggable Base: A factory function constructs an underlying cache for each
+///    shard (default BasicCache).
+///
+/// @tparam KeyType key type
+/// @tparam ValueType value type
+/// @tparam HashFn hash function (default std::hash)
+/// @tparam KeyEqual equality comparer (default std::equal_to)
+/// @tparam Mutex mutex type within the shard (default std::mutex; fiber mutex can be specified)
+/// @tparam ShardBits number of shard bits, number of shards = 2^ShardBits (e.g., 4 -> 16 shards)
+///
+/// Usage example:
+///   using CacheT = trpc::cache::ShardedLRUCache<std::string, std::string, std::hash<std::string>,
+///                                               std::equal_to<std::string>, std::mutex, 4>;
+///   CacheT c(/*capacity*/ 1<<20);  // Total capacity, automatically divided by shards
+///
+template <typename KeyType, typename ValueType, typename HashFn = std::hash<KeyType>,
+          typename KeyEqual = std::equal_to<KeyType>, typename Mutex = std::mutex, std::size_t ShardBits = 4>
+class ShardedLRUCache final : public Cache<KeyType, ValueType, HashFn, KeyEqual> {
+  static_assert(ShardBits < (8 * sizeof(std::size_t)), "ShardBits is too large for size_t");
+  static constexpr std::size_t kNumShards = static_cast<std::size_t>(1) << ShardBits;
+  static_assert((kNumShards & (kNumShards - 1)) == 0 && kNumShards >= 1, "Number of shards must be a power of two");
+
+  using BaseCache = Cache<KeyType, ValueType, HashFn, KeyEqual>;
+  using LruShard = LRUCache<KeyType, ValueType, HashFn, KeyEqual, Mutex>;
+  using ShardPtr = std::unique_ptr<LruShard>;
+  using FactoryFn = std::function<std::unique_ptr<BaseCache>()>;
+
+ public:
+  /// @brief Constructor
+  /// @param capacity Global capacity (to be split across shards; at least 1 per shard)
+  /// @param factory Shard base factory (by default, creates a BasicCache<Key,Value>)
+  explicit ShardedLRUCache(
+      std::size_t capacity,
+      FactoryFn factory = []() { return std::make_unique<BasicCache<KeyType, ValueType, HashFn, KeyEqual>>(); })
+      : total_capacity_(capacity) {
+    if (total_capacity_ == 0) {
+      // Avoid shard construction exceptions caused by 0 capacity
+      total_capacity_ = kNumShards;
+    }
+
+    const std::size_t base = total_capacity_ / kNumShards;
+    std::size_t rem = total_capacity_ % kNumShards;
+
+    for (std::size_t i = 0; i < kNumShards; ++i) {
+      std::size_t shard_cap = base + (rem ? 1 : 0);
+      if (rem) --rem;
+      if (shard_cap == 0) shard_cap = 1;  // At least 1 per shard
+
+      shards_[i] = std::make_unique<LruShard>(factory(), shard_cap);
+    }
+  }
+
+  ~ShardedLRUCache() override = default;
+
+  ShardedLRUCache(const ShardedLRUCache&) = delete;
+  ShardedLRUCache& operator=(const ShardedLRUCache&) = delete;
+
+  ShardedLRUCache(ShardedLRUCache&&) noexcept = default;
+  ShardedLRUCache& operator=(ShardedLRUCache&&) noexcept = default;
+
+  /// @brief Put (copy semantics)
+  bool Put(const KeyType& key, const ValueType& value) override { return ShardOf(key).Put(key, value); }
+
+  /// @brief Put (move semantics)
+  bool Put(const KeyType& key, ValueType&& value) override {
+    return ShardOf(key).Put(key, std::forward<ValueType>(value));
+  }
+
+  /// @brief Get
+  std::optional<ValueType> Get(const KeyType& key) override { return ShardOf(key).Get(key); }
+
+  /// @brief Remove
+  bool Remove(const KeyType& key) override { return ShardOf(key).Remove(key); }
+
+  /// @brief Clear (clear all shards)
+  void Clear() override {
+    for (auto& s : shards_) {
+      s->Clear();
+    }
+  }
+
+  /// @brief Size (sum of the sizes of all shards; approximate real-time value)
+  std::size_t Size() override {
+    std::size_t sum = 0;
+    for (auto& s : shards_) {
+      sum += s->Size();
+    }
+    return sum;
+  }
+
+  /// @brief Returns the total number of shards
+  static constexpr std::size_t NumShards() { return kNumShards; }
+
+  /// @brief Returns the global capacity (specified during construction)
+  std::size_t Capacity() const { return total_capacity_; }
+
+ private:
+  // Select shard (bitwise sharding, requires 2^ShardBits)
+  inline std::size_t ShardIndex(const KeyType& key) const {
+    // HashFn needs to be stateless or default constructible; 
+    // if stateful hashing is required, it can be externally encapsulated
+    const std::size_t h = hasher_(key);
+    return h & (kNumShards - 1);
+  }
+
+  inline LruShard& ShardOf(const KeyType& key) { return *shards_[ShardIndex(key)]; }
+  inline const LruShard& ShardOf(const KeyType& key) const { return *shards_[ShardIndex(key)]; }
+
+ private:
+  std::size_t total_capacity_;
+  std::array<ShardPtr, kNumShards> shards_{};
+  HashFn hasher_{};
+};
+
+}  // namespace trpc::cache

--- a/trpc/util/cache/decorators/sharded_lru_cache_test.cc
+++ b/trpc/util/cache/decorators/sharded_lru_cache_test.cc
@@ -1,0 +1,228 @@
+/*
+ *
+ * Tencent is pleased to support the open source community by making
+ * tRPC available.
+ *
+ * Copyright (C) 2025 Tencent.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "trpc/util/cache/decorators/sharded_lru_cache.h"
+#include "trpc/util/cache/impl/basic_cache.h"
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace trpc::cache::testing {
+
+namespace {
+// Make shard positioning controllable: hash value = key value (easy to route to the target shard by bit)
+struct IdentityHash {
+  size_t operator()(int k) const noexcept { return static_cast<size_t>(k); }
+};
+}  // namespace
+
+// ---------- Basic capabilities (aligned with single-shard LRU use case) ----------
+
+/// @brief Move semantics: data remains intact and of the same size after the move
+TEST(ShardedLRUCacheTest, MoveSemantics) {
+  // ShardBits = 2 => 4 shards; total capacity 16
+  ShardedLRUCache<int, int, IdentityHash, std::equal_to<int>, std::mutex, 2> cache1(16);
+  cache1.Put(1, 1);
+  ASSERT_EQ(cache1.Get(1), 1);
+
+  auto cache2 = std::move(cache1);
+  ASSERT_EQ(cache2.Get(1), 1);
+  ASSERT_EQ(cache2.Size(), 1);
+}
+
+/// @brief Put/Get/Size basic functions
+TEST(ShardedLRUCacheTest, BasicPutGetSize) {
+  ShardedLRUCache<int, int, IdentityHash, std::equal_to<int>, std::mutex, 2> cache(8);
+
+  ASSERT_EQ(cache.Size(), 0);
+  ASSERT_TRUE(cache.Put(1, 1));
+  ASSERT_EQ(cache.Get(1), 1);
+  ASSERT_EQ(cache.Size(), 1);
+}
+
+/// @brief Duplicate key insert: value should be updated and returns false, size unchanged
+TEST(ShardedLRUCacheTest, PutDuplicateKey) {
+  ShardedLRUCache<int, int, IdentityHash, std::equal_to<int>, std::mutex, 2> cache(4);
+
+  ASSERT_TRUE(cache.Put(1, 1));
+  ASSERT_FALSE(cache.Put(1, 2));  // BasicCache::InsertOrAssign returns false if it already exists
+  ASSERT_EQ(cache.Size(), 1);
+  ASSERT_EQ(cache.Get(1), 2);
+}
+
+/// @brief Delete an existing key
+TEST(ShardedLRUCacheTest, RemoveExistingKey) {
+  ShardedLRUCache<int, int, IdentityHash, std::equal_to<int>, std::mutex, 2> cache(4);
+
+  cache.Put(1, 1);
+  ASSERT_TRUE(cache.Remove(1));
+  ASSERT_EQ(cache.Get(1), std::nullopt);
+  ASSERT_EQ(cache.Size(), 0);
+}
+
+/// @brief Delete non-existent keys
+TEST(ShardedLRUCacheTest, RemoveNonExistingKey) {
+  ShardedLRUCache<int, int, IdentityHash, std::equal_to<int>, std::mutex, 2> cache(4);
+
+  ASSERT_FALSE(cache.Remove(1));
+  ASSERT_EQ(cache.Size(), 0);
+}
+
+/// @brief Clear：Clear all shards
+TEST(ShardedLRUCacheTest, ClearCache) {
+  ShardedLRUCache<int, int, IdentityHash, std::equal_to<int>, std::mutex, 2> cache(4);
+
+  cache.Put(1, 1);
+  cache.Put(2, 2);
+  cache.Clear();
+
+  ASSERT_EQ(cache.Size(), 0);
+  ASSERT_EQ(cache.Get(1), std::nullopt);
+  ASSERT_EQ(cache.Get(2), std::nullopt);
+}
+
+// ---------- Sharding semantics (core: strict LRU within a slice, independence between slices) ----------
+
+/// @brief Single-shard strict LRU: Concentrate capacity on the same shard, and verify that eviction is based on the LRU
+///        within the shard.
+TEST(ShardedLRUCacheTest, PerShardEvictionRespectsLRU) {
+  // 2 shards (even shards on shard0, odd shards on shard1), total capacity = 4 => capacity per shard = 2
+  using ShardedCache = ShardedLRUCache<int, int, IdentityHash, std::equal_to<int>, std::mutex, 1>;
+  ShardedCache cache(4);
+
+  // First fill two shards: shard0 with even numbers (0,2), shard1 with odd numbers (1,3)
+  cache.Put(0, 0);  // shard0
+  cache.Put(2, 2);  // shard0
+  cache.Put(1, 1);  // shard1
+  cache.Put(3, 3);  // shard1
+
+  // Access 0 is promoted to the MRU of shard0, the order within the shard (MRU->LRU): 0, 2
+  ASSERT_EQ(cache.Get(0), 0);
+
+  // Insert another key 4 into shard0, triggering shard0 to evict LRU(2), without affecting shard1(1,3)
+  cache.Put(4, 4);  // shard0
+
+  ASSERT_EQ(cache.Get(2), std::nullopt);  // Evicted (on-shard LRU)
+  ASSERT_EQ(cache.Get(0), 0);             // Still in（MRU）
+  ASSERT_EQ(cache.Get(4), 4);             // New Insert
+
+  // Shard 1 is not affected
+  ASSERT_EQ(cache.Get(1), 1);
+  ASSERT_EQ(cache.Get(3), 3);
+
+  // The current total size should be 4 (both shards are full)
+  ASSERT_EQ(cache.Size(), 4u);
+}
+
+/// @brief Single-shard degenerate (ShardBits=0): Behavior equivalent to "global single-shard LRU", convenient for
+///        aligning single-shard use cases
+TEST(ShardedLRUCacheTest, SingleShardBehavesLikeGlobalLRU) {
+  // Single shard: capacity = 3, equivalent to a single LRU capacity = 3
+  ShardedLRUCache<int, int, IdentityHash, std::equal_to<int>, std::mutex, 0> cache(3);
+
+  cache.Put(1, 1);
+  cache.Put(2, 2);
+  cache.Put(3, 3);
+
+  // Access 1 promoted to MRU
+  ASSERT_EQ(cache.Get(1), 1);
+
+  // Insert 4th -> Evict LRU(2)
+  cache.Put(4, 4);
+
+  ASSERT_EQ(cache.Get(2), std::nullopt);  // Evicted
+  ASSERT_EQ(cache.Get(1), 1);
+  ASSERT_EQ(cache.Get(3), 3);
+  ASSERT_EQ(cache.Get(4), 4);
+  ASSERT_EQ(cache.Size(), 3u);
+}
+
+// ---------- Concurrent scenarios ----------
+
+/// @brief High Concurrency Put: Verify consistency (Hits == Size)
+TEST(ShardedLRUCacheTest, ConcurrentPut) {
+  constexpr int capacity = 1000;
+  // Multiple shards (8 shards), shared lock contention
+  ShardedLRUCache<int, int, IdentityHash, std::equal_to<int>, std::mutex, 3> cache(capacity);
+
+  constexpr int threads_num = 8;
+  constexpr int puts_per_thread = 200;
+  constexpr int puts_num = threads_num * puts_per_thread;
+
+  std::vector<std::thread> threads;
+  std::atomic<int> key_gen{0};
+
+  for (int i = 0; i < threads_num; ++i) {
+    threads.emplace_back([&]() {
+      for (int j = 0; j < puts_per_thread; ++j) {
+        int key = key_gen.fetch_add(1, std::memory_order_relaxed);
+        cache.Put(key, key);
+      }
+    });
+  }
+  for (auto& t : threads) t.join();
+
+  int hits{0}, misses{0};
+  for (int key = 0; key < puts_num; ++key) {
+    if (cache.Get(key) == std::nullopt) {
+      ++misses;
+    } else {
+      ++hits;
+    }
+  }
+
+  ASSERT_EQ(hits, static_cast<int>(cache.Size()));
+  ASSERT_EQ(misses, puts_num - static_cast<int>(cache.Size()));
+}
+
+/// @brief Highly concurrent Get: Maintaining correctness in both hit and miss scenarios
+TEST(ShardedLRUCacheTest, ConcurrentGet) {
+  constexpr int capacity = 1000;
+  ShardedLRUCache<int, int, IdentityHash, std::equal_to<int>, std::mutex, 3> cache(capacity);
+
+  for (int key = 0; key < capacity; ++key) {
+    cache.Put(key, key);
+  }
+
+  constexpr int threads_num = 8;
+  constexpr int gets_per_thread = 200;
+  std::vector<std::thread> threads;
+
+  for (int i = 0; i < threads_num; ++i) {
+    threads.emplace_back([&, i]() {
+      for (int j = 0; j < gets_per_thread; ++j) {
+        int key = j + i * gets_per_thread;
+        if (key < capacity) {
+          ASSERT_EQ(cache.Get(key), key);
+        } else {
+          ASSERT_EQ(cache.Get(key), std::nullopt);
+        }
+      }
+    });
+  }
+  for (auto& t : threads) t.join();
+}
+
+}  // namespace trpc::cache::testing


### PR DESCRIPTION
## Motivation

* 在高并发场景下，单实例 LRU 受限于**全局互斥**，在多线程/协程下出现明显锁争用，吞吐与延迟抖动明显。
* 工业界的主流做法是 **Sharded LRU**：按 `hash(key)` 将 Key 均匀分散到多片，**片内严格 LRU**、**片间近似全局 LRU**，从而显著降低锁竞争、提升并发度。
* 本 PR 落地 `ShardedLRUCache`，作为**分片编排层**，复用已有 `LRUCache` 的逻辑与单测，降低实现和维护风险，并为后续 Fiber 互斥、异步提升、性能基准打下基础。

---

## Design

### 分片（Sharding）

* **分片数**：`num_shards = 2^ShardBits`（编译期常量，默认 `ShardBits=4` → 16 片）。
* **路由规则**：`shard_id = Hash(key) & (num_shards - 1)`（位与，要求分片数为 2 的幂）。
* **容量切分**：总容量 `total` 等分到各片：

  * `base = total / num_shards`，余数 `rem = total % num_shards`；
  * 前 `rem` 个分片 `base+1`，其余 `base`；**每片至少 1**。
* **全局 Size**：聚合各片 `Size()`（近似实时值）。

### 片内策略（strict LRU per shard）

* 每个分片内部复用 **`LRUCache<Key,Value,Mutex>`**（双向链表 + 哈希索引；命中提升到 MRU；容量满时淘汰队尾 LRU）。
* 片内有且仅有一把互斥（模板参数 `Mutex`，默认 `std::mutex`；后续支持 `FiberMutex`）。

### 并发模型

* **片间无共享互斥**，并发度≈分片数；
* **片内加锁**保护 LRU 元数据与底座存取；
* 默认底座为 `BasicCache`（并发 HashMap）。若验证存在**双重加锁**的不可忽视开销，将切换为**无锁底座 MapCache**（仅 `unordered_map`，依赖 LRU 层互斥）。

---

## Public API

```cpp
template <
  typename KeyType,
  typename ValueType,
  typename HashFn   = std::hash<KeyType>,
  typename KeyEqual = std::equal_to<KeyType>,
  typename Mutex    = std::mutex,
  std::size_t ShardBits = 4
>
class ShardedLRUCache : public Cache<KeyType, ValueType, HashFn, KeyEqual> {
 public:
  using FactoryFn = std::function<std::unique_ptr<Cache<KeyType,ValueType,HashFn,KeyEqual>>()>;

  explicit ShardedLRUCache(std::size_t capacity,
                           FactoryFn factory = [] {
                             return std::make_unique<BasicCache<KeyType,ValueType,HashFn,KeyEqual>>();
                           });

  bool Put(const KeyType& key, const ValueType& value) override;
  bool Put(const KeyType& key, ValueType&& value) override;
  std::optional<ValueType> Get(const KeyType& key) override;
  bool Remove(const KeyType& key) override;
  void Clear() override;
  std::size_t Size() override;

  static constexpr std::size_t NumShards();
  std::size_t Capacity() const;
};
```

### Usage example

```cpp
// 16-shard, total capacity = 1<<20
ShardedLRUCache<std::string, std::string> cache(1 << 20);
cache.Put("k", "v");
auto v = cache.Get("k"); // -> "v"
```

---

## Tests

新增 `sharded_lru_cache_test.cc`，覆盖点：

1. **Move 语义**：移动构造/赋值后数据一致、Size 正确。
2. **Basic Put/Get/Size**：基本操作与容量计数。
3. **Duplicate Key**：更新值不改变 Size（与底座 InsertOrAssign 语义对齐）。
4. **Remove/Remove non-existing**：存在/不存在删除路径。
5. **Clear**：清空所有分片。
6. **Per-shard LRU**：构造可控哈希（IdentityHash），让插入集中到指定分片，验证**片内严格 LRU 淘汰**、**片间互不影响**。
7. **Single shard 退化**：`ShardBits=0` 时行为等价于全局单片 LRU（与现有 `LRUCache` 用例对齐）。
8. **并发 Put/Get**：8 线程高并发写入/读取，断言 `hits == Size()`、正确命中/未命中分布。

> 本地已在 Debug/Release 下通过，支持 gtest 跑法与 CI 集成。建议在 TSan/ASan 下再跑一遍以兜底数据竞争与越界。

---

## 为什么要基于 LRUCache（装饰器）构建而不是在裸缓存上重新实现？

**选择：Sharded 编排层 + 片内复用 `LRUCache`（现有装饰器）**。

### 优势

* **逻辑复用 & 行为一致**：LRU 细节（命中提升、溢出淘汰、边界 case）已经在单分片用例中验证；避免**重复实现**导致的行为漂移。
* **测试负担小**：Sharded 层只关注“分片路由与容量切分”；LRU 行为由既有单测保障，组合起来更易维护。
* **易于扩展**：后续若要接入 `Synchronized`/`Blocking`/`TTL` 等装饰器或替换为 `AsyncLRU`（异步提升），**分片层无需改动**。
* **更清晰的模块边界**：Sharded 负责并发度与路由，LRU 负责策略；职责单一，易读易演进。

### 代价 / 缺点

* **潜在双重加锁**：若分片底座是并发容器（如 `BasicCache`），片内 LRU 已有互斥，再调用到底座的并发结构会**重复加锁**。

  * **缓解方案**：提供/切换到底座 **无锁 `MapCache`**（仅 `unordered_map`），由 LRU 的互斥统一保护。
* **轻微的虚调用/拼装开销**：LRU 作为装饰器包装底座，较“写死一体化实现”多一次间接，但在分片降低锁争用后，这点开销可忽略。
* **近似全局 LRU**：Sharded 模式全局上是“近似” LRU（片内严格、片间独立），不保证严格全局次序（与 LevelDB/RocksDB 的工程折中一致）。

> 结论：在**可维护性、扩展性、测试复用**与**可接受的性能折中**之间，基于 `LRUCache` 的分片编排是更稳妥的路径。

---

## Compatibility

* 纯新增类型，不修改已有公共接口；与现有 `Cache`/`LRUCache` 并存。
* 默认哈希 `std::hash<Key>`、比较器 `std::equal_to<Key>`；可自定义。
* 默认互斥 `std::mutex`；未来 PR 将提供 `FiberMutex` 版本。

---

## Performance (plan)

* micro-bench：`Put:Get = 1:9` 与 `5:5` 两种混合比；容量击穿与热点 Key 两种分布；对比：

  1. `LRUCache (single shard)`
  2. `ShardedLRUCache (ShardBits = 0/2/4/6)`
  3. `BasicCache` 直存（无 LRU）
* 指标：QPS、p99 延迟、锁争用（`perf lock`）、CPU 利用、cache line 失效；
* 期望：随着 `ShardBits` 提升，**锁争用显著下降**、吞吐上升；在热点 Key 工况下收益最明显。

---

## Follow-ups

* **FiberMutex 版本**：模板化互斥，针对协程运行时切换 `trpc::FiberMutex`。
* **无锁/近无锁增强**：命中提升改为异步批处理（promote-queue + 批量 move-to-head），淘汰回调/大对象析构锁外执行。
* **底座 `MapCache`**：提供无并发底座以避免双重加锁；必要时作为默认底座切换。
* **Blocking/Singleflight**：装饰器抑制缓存击穿（miss 时 per-key 等待）。
* **Benchmark & 文档**：补充完整基准与使用说明（examples/，设计文档 design.md）。